### PR TITLE
Replace object spread with object.assign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+ - Replaced usage of object spread operator in `SendEventOnHandshakeLeaf` with `Object.assign`,
+   as it just makes life easier when use `babel` (since it's technically still a proposal).
+
 ## [0.2.0] - 2018-06-19
 
 Some minor cleanup, automation, and fixes. Also added some warnings in the `userId` leafs

--- a/leafs/SendEventOnHandshakeLeaf.js
+++ b/leafs/SendEventOnHandshakeLeaf.js
@@ -34,7 +34,7 @@ class SendEventOnHandshakeLeaf extends BSClientLeaf {
          * @type {Object}
          * @private
          */
-        this._payload = { ...payload };
+        this._payload = Object.assign({}, payload);
         /**
          *
          * @type {boolean}
@@ -78,7 +78,7 @@ class SendEventOnHandshakeLeaf extends BSClientLeaf {
      * @return {Object}
      */
     get payload() {
-        return { ...this._payload };
+        return Object.assign({}, this._payload);
     }
 
     /**
@@ -87,7 +87,7 @@ class SendEventOnHandshakeLeaf extends BSClientLeaf {
      * @param {Object} payload
      */
     set payload(payload) {
-        this._payload = { ...payload };
+        this._payload = Object.assign({}, payload);
     }
 
     // endregion


### PR DESCRIPTION
It's just easier when working with `babel` if we don't use Object spread.